### PR TITLE
Fixed serve command to run on localhost:3000 as fixed baseURL to the port

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "source/index.js",
   "scripts": {
     "build": "NODE_ENV=production webpack --mode=production --progress",
+    "serve": "serve -p 3000 ./dist",
     "dev": "webpack --mode=development --progress --watch",
     "test": "jest",
     "test:update": "jest --updateSnapshot"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
     plugins: [
         new HtmlWebpackPlugin({
             title: "Sample Application - Kiosked",
-            baseURL: `http://localhost/`,
+            baseURL: 'http://localhost:3000/',
             template: path.join(RESOURCES, "template.pug"),
             favicon: path.join(RESOURCES, "sample.ico"),
             publicPath: "",


### PR DESCRIPTION
Was having error err_connection_refused for bundle.js and sample.ico because the baseURL on 
webpack.config was pointing to `http://localhost/` instead of `http://localhost + port/`.

Fixes #1 